### PR TITLE
Fix syntax highlighting on access control expr with parentheses

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "configurations": [
+    {
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "name": "Launch Extension",
+      "outFiles": [
+        "${workspaceFolder}/out/**/*.js"
+      ],
+      "request": "launch",
+      "type": "extensionHost"
+    }
+  ]
+}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,22 +2,22 @@
 
 ## Organization
 
-* `package.json`: This is the manifest file that declares the Exograph language support as well as contributions to other languages (markdown).
-* `src/syntaxes/exograph.tmLanguage.template.json`: This is the Textmate grammar file that is used for tokenization. It contains a few placeholders that will be filled in by the build script (./build.js).
-* `src/language-configuration.json`: This is the language configuration, defining the tokens that are used for comments and brackets.
+- `package.json`: This manifest file declares the Exograph language support and contributions to other languages (markdown).
+- `src/syntaxes/exograph.tmLanguage.template.json`: This is the Textmate grammar file used for tokenization. It contains a few placeholders that will be filled in by the build script (./build.js).
+- `src/language-configuration.json`: This is the language configuration, defining the tokens used for comments and brackets.
 
 ## Debugging the extension
 
-1. Press the "Debug" button (the triangle on the left side) or Press `F5` to open a new window with your extension loaded. Then run the extension.
+1. Press the "Debug" button (the triangle on the left side) or Press `F5` to open a new window with your extension loaded. Then, run the extension.
 2. In the window opened by the debugger, open `example.exo`, `example.md`, and `example.exotest` to check the correctness of syntax highlighting.
 
 ## Making changes
 
-1. Run `npm run build` every time you change the `exograph.tmLanguage.template.json` file. This will update the `syntaxes/exograph.tmLanguage.json` file.
+1. Run `npm run build` every time you change the `exograph.tmLanguage.template.json` file. This will update the `out/syntaxes/exograph.tmLanguage.json` file.
 2. You can relaunch the extension from the debug toolbar after making changes to the files listed above.
 3. You can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes.
 
-Tip: `View` -> `Command Palette` -> `Developer: Inspect Editor Tokens and Scope` is a very useful tool. It will bring up a palette and as you click around an example file, it will show matching scopes.
+Tip: `View` -> `Command Palette` -> `Developer: Inspect Editor Tokens and Scope` is a handy tool. It will bring up a palette, and as you click around an example file, it will show matching scopes.
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Exograph Language Support
 
-This extension provides syntax highlighting for Exograph files (the ".exo" extension) and Exograph code blocks in Markdown files.
+This extension provides syntax highlighting for Exograph files (the ".exo" and ".exotest" extensions) and Exograph code blocks in Markdown files.
 
 ## Installation
 

--- a/src/syntaxes/exograph.tmLanguage.template.json
+++ b/src/syntaxes/exograph.tmLanguage.template.json
@@ -198,6 +198,15 @@
         },
         {
           "include": "#comments"
+        },
+        {
+          "begin": "(\\()",
+          "patterns": [
+            {
+              "include": "#expressions"
+            }
+          ],
+          "end": "(\\))"
         }
       ]
     },

--- a/test/example.exo
+++ b/test/example.exo
@@ -1,7 +1,7 @@
 @postgres
 module ConcertVenues {
   @table("concerts")
-  @access(query=AuthContext.role == "ROLE_ADMIN" || self.published || price <= 10, 
+  @access(query=AuthContext.role == "ROLE_ADMIN" || self.published || (price <= 10 && price >= 5), 
           mutation=AuthContext.role == "ROLE_ADMIN")
   type Concert {
     @pk id: Int = autoIncrement() // comment after annotation
@@ -19,6 +19,16 @@ module ConcertVenues {
     published: Boolean
     occupancy: Int = 200 // highlighting of numbers in default field
     @singlePrecision latitude: Floatq
+  }
+
+  @access(
+    query = AuthContext.role == "admin"|| self.documentUsers.some(du => du.userId == AuthContext.id && du.read),
+    mutation = AuthContext.role == "admin" || self.documentUsers.some(du => du.userId == AuthContext.id && du.write)
+  )  
+  type Document {
+    @pk id: Int = autoIncrement()
+    content: String
+    documentUsers: Set<DocumentUser>
   }
 }
 


### PR DESCRIPTION
We had a highlighting issue where an expression such as `(price < 100)` would mis-highlight the subsequent expressions. We now include a rule to consider expressions inside parentheses.